### PR TITLE
Shuffle Players - Make Sure Users Dont Play In Join Order

### DIFF
--- a/src/lobby/tournament/matchmaker/DoubleEliminationMatchmaker.spec.ts
+++ b/src/lobby/tournament/matchmaker/DoubleEliminationMatchmaker.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { MatchOptions } from "@socialgorithm/model";
+import { MatchOptions, Player } from "@socialgorithm/model";
 import { DoubleEliminationMatch } from "./DoubleEliminationMatch";
 import DoubleEliminationMatchmaker from "./DoubleEliminationMatchmaker";
 
@@ -16,79 +16,84 @@ describe("Double Elimination Matchmaker", () => {
         const matchmaker = new DoubleEliminationMatchmaker([p1, p2, p3, p4], matchOptions);
         const allMatches: DoubleEliminationMatch[] = [];
         let matches: DoubleEliminationMatch[] = [];
+        const shuffledPlayers : Player[] = matchmaker.getPlayers();
+        const sp1 = shuffledPlayers[0];
+        const sp2 = shuffledPlayers[1];
+        const sp3 = shuffledPlayers[2];
+        const sp4 = shuffledPlayers[3];
 
         // Round 1
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(2);
-        expect(matches[0].players).to.deep.equal([p1, p2]);
-        expect(matches[1].players).to.deep.equal([p3, p4]);
+        expect(matches[0].players).to.deep.equal([sp1, sp2]);
+        expect(matches[1].players).to.deep.equal([sp3, sp4]);
         // parents
         expect(matches[0].parentMatches).to.have.length(0);
         expect(matches[1].parentMatches).to.have.length(0);
 
         // Round 2
-        matches[0].winner = 0; // p1
-        matches[1].winner = 1; // p4
+        matches[0].winner = 0; // sp1
+        matches[1].winner = 1; // sp4
         matches[0].state = "finished";
         matches[1].state = "finished";
         matchmaker.updateStats(allMatches);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(2);
-        expect(matches[0].players).to.deep.equal([p1, p4]); // winning bracket
-        expect(matches[1].players).to.deep.equals([p2, p3]); // losing bracket
+        expect(matches[0].players).to.deep.equal([sp1, sp4]); // winning bracket
+        expect(matches[1].players).to.deep.equals([sp2, sp3]); // losing bracket
         // parents
         expect(matches[0].parentMatches).to.have.length(2);
         expect(matches[1].parentMatches).to.have.length(0);
         expect(matches[0].parentMatches).to.deep.equal([
             {
                 playerIndex: 0,
-                parent:  allMatches[0].matchID, // P1-P2
+                parent:  allMatches[0].matchID, // SP1-SP2
             },
             {
                 playerIndex: 1,
-                parent: allMatches[1].matchID, // P3-P4
+                parent: allMatches[1].matchID, // SP3-SP4
             },
         ]);
 
         // Round 3
-        matches[0].winner = 1; // p4
-        matches[1].winner = 0; // p2
+        matches[0].winner = 1; // sp4
+        matches[1].winner = 0; // sp2
         matches[0].state = "finished";
         matches[1].state = "finished";
         matchmaker.updateStats(allMatches);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].players).to.deep.equal([p1, p2]);
+        expect(matches[0].players).to.deep.equal([sp1, sp2]);
         // parents
         expect(matches[0].parentMatches).to.have.length(1);
         expect(matches[0].parentMatches).to.deep.equal([
             {
                 playerIndex: 1,
-                parent: allMatches[3].matchID, // P2-P3
+                parent: allMatches[3].matchID, // SP2-SP3
             },
         ]);
 
         // Round 4
-        matches[0].winner = 0; // p1
+        matches[0].winner = 0; // sp1
         matches[0].state = "finished";
         matchmaker.updateStats(allMatches);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].players).to.deep.equal([p4, p1]);
+        expect(matches[0].players).to.deep.equal([sp4, sp1]);
         // parents
         expect(matches[0].parentMatches).to.have.length(2);
         expect(matches[0].parentMatches).to.deep.equal([
             {
                 playerIndex: 0,
-                parent: allMatches[2].matchID, // P1-P4
+                parent: allMatches[2].matchID, // SP1-SP4
             },
             {
                 playerIndex: 1,
-                parent: allMatches[4].matchID, // P1-P2
+                parent: allMatches[4].matchID, // SP1-SP2
             },
         ]);
 
@@ -99,58 +104,64 @@ describe("Double Elimination Matchmaker", () => {
         const matchmaker = new DoubleEliminationMatchmaker([p1, p2, p3, p4, p5], matchOptions);
         const allMatches: DoubleEliminationMatch[] = [];
         let matches: DoubleEliminationMatch[] = [];
+        const shuffledPlayers : Player[] = matchmaker.getPlayers();
+        const sp1 = shuffledPlayers[0];
+        const sp2 = shuffledPlayers[1];
+        const sp3 = shuffledPlayers[2];
+        const sp4 = shuffledPlayers[3];
+        const sp5 = shuffledPlayers[4];
 
         // Round 1
-        expect(matchmaker.getRanking()).to.deep.equal(["P1", "P2", "P3", "P4", "P5"]);
+        expect(matchmaker.getRanking()).to.deep.equal(shuffledPlayers);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(2);
-        expect(matches[0].players).to.deep.equal([p1, p2]);
-        expect(matches[1].players).to.deep.equal([p3, p4]);
+        expect(matches[0].players).to.deep.equal([sp1, sp2]);
+        expect(matches[1].players).to.deep.equal([sp3, sp4]);
 
         // Round 2
-        matches[0].winner = 0; // p1
-        matches[1].winner = 0; // p3
+        matches[0].winner = 0; // sp1
+        matches[1].winner = 0; // sp3
         matchmaker.updateStats(allMatches);
-        expect(matchmaker.getRanking()).to.deep.equal(["P1", "P3", "P2", "P4", "P5"]);
+        expect(matchmaker.getRanking()).to.deep.equal([sp1, sp3, sp2, sp4, sp5]);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(2);
-        expect(matches[0].players).to.deep.equal([p5, p1]); // winning bracket
-        expect(matches[1].players).to.deep.equals([p2, p4]); // losing bracket
+        expect(matches[0].players).to.deep.equal([sp5, sp1]); // winning bracket
+        expect(matches[1].players).to.deep.equals([sp2, sp4]); // losing bracket
 
         // Round 3
-        matches[0].winner = 0; // p5
-        matches[1].winner = 0; // p2
+        matches[0].winner = 0; // sp5
+        matches[1].winner = 0; // sp2
         matchmaker.updateStats(allMatches);
-        expect(matchmaker.getRanking()).to.deep.equal(["P3", "P5", "P1", "P2", "P4"]);
+        expect(matchmaker.getRanking()).to.deep.equal([sp3, sp5, sp1, sp2, sp4]);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(2);
-        expect(matches[0].players).to.deep.equal([p3, p5]);
-        expect(matches[1].players).to.deep.equal([p1, p2]);
+        expect(matches[0].players).to.deep.equal([sp3, sp5]);
+        expect(matches[1].players).to.deep.equal([sp1, sp2]);
 
         // Round 4
-        matches[0].winner = 0; // p3
-        matches[1].winner = 0; // p1
+        matches[0].winner = 0; // sp3
+        matches[1].winner = 0; // sp1
         matchmaker.updateStats(allMatches);
-        expect(matchmaker.getRanking()).to.deep.equal(["P3", "P1", "P5", "P2", "P4"]);
+        expect(matchmaker.getRanking()).to.deep.equal([sp3, sp1, sp5, sp2, sp4]);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].players).to.deep.equal([p1, p5]);
+        expect(matches[0].players).to.deep.equal([sp1, sp5]);
 
         // Round 5
-        matches[0].winner = 0; // p1
+        matches[0].winner = 0; // sp1
         matchmaker.updateStats(allMatches);
-        expect(matchmaker.getRanking()).to.deep.equal(["P3", "P1", "P2", "P5", "P4"]);
+        expect(matchmaker.getRanking()).to.deep.equal([sp3, sp1, sp2, sp5, sp4]);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].players).to.deep.equal([p3, p1]);
+        expect(matches[0].players).to.deep.equal([sp3, sp1]);
 
         // Round 6
-        matches[0].winner = 1; // p1
+        matches[0].winner = 1; // sp1
         matchmaker.updateStats(allMatches);
         matches = matchmaker.getRemainingMatches();
         allMatches.push(...matches);
@@ -158,7 +169,7 @@ describe("Double Elimination Matchmaker", () => {
         expect(matches).to.be.empty;
 
         // Test Ranking
-        expect(matchmaker.getRanking()).to.deep.equal(["P1", "P3", "P5", "P2", "P4"]);
+        expect(matchmaker.getRanking()).to.deep.equal([sp1, sp3, sp5, sp2, sp4]);
 
         done();
     });
@@ -166,15 +177,21 @@ describe("Double Elimination Matchmaker", () => {
     it("resolves ties", done => {
         const matchmaker = new DoubleEliminationMatchmaker([p1, p2], matchOptions);
         let matches = matchmaker.getRemainingMatches();
+        const shuffledPlayers : Player[] = matchmaker.getPlayers();
+        const sp1 = shuffledPlayers[0];
+        const sp2 = shuffledPlayers[1];
+        const sp3 = shuffledPlayers[2];
+        const sp4 = shuffledPlayers[3];
+
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].players).to.deep.equal([p1, p2]);
+        expect(matches[0].players).to.deep.equal([sp1, sp2]);
 
         matches[0].winner = -1; // TIE
         let tiedMatchmatchID = matches[0].matchID;
         matchmaker.updateStats(matches);
         matches = matchmaker.getRemainingMatches();
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].players).to.deep.equal([p1, p2]);
+        expect(matches[0].players).to.deep.equal([sp1, sp2]);
         expect(matches[0].options.timeout).to.equal(50);
         expect(matches[0].parentMatches).to.deep.equal([{ playerIndex: 0, parent: tiedMatchmatchID }, { playerIndex: 1, parent: tiedMatchmatchID }]);
 
@@ -183,7 +200,7 @@ describe("Double Elimination Matchmaker", () => {
         matchmaker.updateStats(matches);
         matches = matchmaker.getRemainingMatches();
         expect(matches).to.have.lengthOf(1);
-        expect(matches[0].players).to.deep.equal([p1, p2]);
+        expect(matches[0].players).to.deep.equal([sp1, sp2]);
         expect(matches[0].options.timeout).to.equal(25);
         expect(matches[0].parentMatches).to.deep.equal([{ playerIndex: 0, parent: tiedMatchmatchID }, { playerIndex: 1, parent: tiedMatchmatchID }]);
 

--- a/src/lobby/tournament/matchmaker/DoubleEliminationMatchmaker.ts
+++ b/src/lobby/tournament/matchmaker/DoubleEliminationMatchmaker.ts
@@ -22,6 +22,7 @@ const RESULT_TIE = -1;
  *
  */
 export default class DoubleEliminationMatchmaker implements IMatchmaker {
+  private players: Player[];
   private finished: boolean;
   private playedMatches: Match[];
   private ranking: string[];
@@ -32,7 +33,8 @@ export default class DoubleEliminationMatchmaker implements IMatchmaker {
   private waitingForFinal: Player[];
   private unlinkedMatches: DoubleEliminationMatch[] = [];
 
-  constructor(private players: Player[], private options: MatchOptions) {
+  constructor(players: Player[], private options: MatchOptions) {
+    this.players = this.shufflePlayers(players);
     this.playedMatches = [];
     this.processedMatches = [];
     this.ranking = this.players.map(player => player);
@@ -41,6 +43,15 @@ export default class DoubleEliminationMatchmaker implements IMatchmaker {
       this.playerStats[player] = { player, wins: 0, losses: 0 };
     });
     this.waitingForFinal = [];
+  }
+
+  private shufflePlayers([...players]: Player[]): Player[] {
+    let m = players.length;
+    while (m) {
+      const i = Math.floor(Math.random() * m--);
+      [players[m], players[i]] = [players[i], players[m]];
+    }
+    return players;
   }
 
   public isFinished(): boolean {
@@ -284,4 +295,9 @@ export default class DoubleEliminationMatchmaker implements IMatchmaker {
 
     match.parentMatches = parentMatches;
   }
+
+  public getPlayers() : Player[] {
+    return [...this.players];
+  }
+
 }


### PR DESCRIPTION
Re-order Players to insure order is not based on when they joined the lobby.